### PR TITLE
fix(#73): semantic url info

### DIFF
--- a/src/providers/api-provider.tsx
+++ b/src/providers/api-provider.tsx
@@ -32,7 +32,7 @@ const cacheNetwork = (network: Network): void => {
 };
 
 const initialState: StoreState = {
-  network: getInitialSetting<Network>('network', 'pangolin'),
+  network: getInitialSetting<Network>('network', 'polkadot'),
   accounts: null,
   networkStatus: 'pending',
 };

--- a/src/utils/helper/url.ts
+++ b/src/utils/helper/url.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-globals */
-import { mapKeys } from 'lodash';
 import { Network, StorageInfo, ValueOf } from './../../model';
 import { readStorage } from './storage';
 
@@ -8,31 +6,11 @@ interface HashInfo {
   toAccount?: string;
 }
 
-interface HashShort {
-  n?: Network;
-  t?: string;
-}
-
 type SettingKey = keyof StorageInfo | keyof HashInfo;
 
 type SettingValue = ValueOf<HashInfo> & ValueOf<StorageInfo>;
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type AdapterMap<T extends object, D extends object> = {
-  [key in keyof T]?: keyof D;
-};
-
-const toShort: AdapterMap<HashInfo, HashShort> = {
-  network: 'n',
-  toAccount: 't',
-};
-
-const toLong: AdapterMap<HashShort, HashInfo> = Object.entries(toShort).reduce(
-  (acc, cur) => ({ ...acc, [cur[1]]: cur[0] }),
-  {}
-);
-
-function hashToObj(): { [key in keyof HashShort]: string } {
+function hashToObj(): { [key in keyof HashInfo]: string } {
   try {
     const str = decodeURIComponent(location.hash);
 
@@ -44,14 +22,13 @@ function hashToObj(): { [key in keyof HashShort]: string } {
         const [key, value] = cur.split('=');
 
         return { ...acc, [key]: value };
-      }, {}) as { [key in keyof HashShort]: string };
+      }, {}) as { [key in keyof HashInfo]: string | Network };
   } catch (err) {
-    return { n: '', t: '' };
+    return { network: '', toAccount: '' };
   }
 }
 
-export function patchUrl(info: HashInfo): void {
-  const data = mapKeys(info, (_, key) => toShort[key as keyof HashInfo]);
+export function patchUrl(data: HashInfo): void {
   const oData = hashToObj();
   const hash = Object.entries({ ...oData, ...data })
     .filter(([_, value]) => !!value)
@@ -66,14 +43,8 @@ export function patchUrl(info: HashInfo): void {
   }
 }
 
-export function getInfoFromHash(): HashInfo {
-  const info = hashToObj();
-
-  return mapKeys(info, (_, key) => toLong[key as keyof HashShort]);
-}
-
 export function getInitialSetting<T = SettingValue | string>(key: SettingKey, defaultValue: T): T {
-  const fromHash = getInfoFromHash();
+  const fromHash = hashToObj();
   const fromStorage = readStorage();
 
   return (fromHash[key as keyof HashInfo] ?? fromStorage[key as keyof StorageInfo] ?? defaultValue) as unknown as T;


### PR DESCRIPTION
In fact, this pr has nothing to do other than changing the default chain to Polkadot if we can't find the network info from URL hash or localStorage.

As mentioned in issue #25,  the URL has been encoded, this is considered a better practice in most front-end projects for security or some other reasons. It is deliberately no compatibility with the non-escaped URL here.

Alternatively, the network information is stored in the not very semantic field 'n'. This is also deliberate, to make it more difficult for outsiders to guess the meaning of the code, but seems that it is not popular, so I have restored it to a semantic filed in this pr.